### PR TITLE
[Fix] 조건부 유니크 제약을 활용한 회원탈퇴 기능 구현

### DIFF
--- a/.github/workflows/dev-ci-check.yml
+++ b/.github/workflows/dev-ci-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SUBMODULE_KEY }}
+          token: ${{ secrets.SUBMODULE_ACCESS_TOKEN }}
           submodules: true
 
       - name: Update Submodule

--- a/.github/workflows/prod-ci-check.yml
+++ b/.github/workflows/prod-ci-check.yml
@@ -11,12 +11,12 @@ jobs:
       contents: read
       checks: write
       pull-requests: write
-    environment: dev
+    environment: prod
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SUBMODULE_KEY }}
+          token: ${{ secrets.SUBMODULE_ACCESS_TOKEN }}
           submodules: true
 
       - name: Update Submodule

--- a/.github/workflows/prod-cicd.yml
+++ b/.github/workflows/prod-cicd.yml
@@ -4,12 +4,12 @@ name: Back-Prod Build and Deploy
 #  push:
 #    branches: [ "main" ]
 
-on: [workflow_dispatch]
+on: [ workflow_dispatch ]
 
 jobs:
   ci:
     runs-on: ubuntu-24.04
-    environment: dev
+    environment: prod
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/backend/src/main/java/com/pickeat/backend/global/BaseEntity.java
+++ b/backend/src/main/java/com/pickeat/backend/global/BaseEntity.java
@@ -9,7 +9,6 @@ import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import org.hibernate.annotations.SoftDelete;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -18,7 +17,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @EqualsAndHashCode(of = "id")
-@SoftDelete
 public class BaseEntity {
 
     @Id
@@ -32,4 +30,6 @@ public class BaseEntity {
     @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt = null;
 }

--- a/backend/src/main/java/com/pickeat/backend/pickeat/domain/Participant.java
+++ b/backend/src/main/java/com/pickeat/backend/pickeat/domain/Participant.java
@@ -6,10 +6,14 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE participant SET deleted_at = NOW() WHERE id = ?")
 public class Participant extends BaseEntity {
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/pickeat/backend/pickeat/domain/Pickeat.java
+++ b/backend/src/main/java/com/pickeat/backend/pickeat/domain/Pickeat.java
@@ -7,10 +7,14 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE pickeat SET deleted_at = NOW() WHERE id = ?")
 public class Pickeat extends BaseEntity {
 
     @Embedded

--- a/backend/src/main/java/com/pickeat/backend/restaurant/domain/Picture.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/domain/Picture.java
@@ -6,11 +6,15 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Embeddable
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE picture SET deleted_at = NOW() WHERE id = ?")
 public class Picture {
 
     @Column(name = "picture_key")

--- a/backend/src/main/java/com/pickeat/backend/restaurant/domain/Restaurant.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/domain/Restaurant.java
@@ -8,10 +8,14 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE restaurant SET deleted_at = NOW() WHERE id = ?")
 public class Restaurant extends BaseEntity {
 
     @Embedded

--- a/backend/src/main/java/com/pickeat/backend/restaurant/domain/RestaurantLike.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/domain/RestaurantLike.java
@@ -5,9 +5,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE restaurant_like SET deleted_at = NOW() WHERE id = ?")
 public class RestaurantLike extends BaseEntity {
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/pickeat/backend/restaurant/domain/repository/RestaurantBulkRepository.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/domain/repository/RestaurantBulkRepository.java
@@ -6,6 +6,7 @@ import com.pickeat.backend.restaurant.domain.RestaurantInfo;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,7 @@ public class RestaurantBulkRepository {
                 INSERT INTO restaurant
                   (name, food_category, distance, road_address_name, place_url,
                    tags, picture_key, picture_url, is_excluded, like_count,
-                   pickeat_id, created_at, updated_at, deleted)
+                   pickeat_id, created_at, updated_at, deleted_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """;
 
@@ -67,7 +68,7 @@ public class RestaurantBulkRepository {
 
                 ps.setTimestamp(12, now);
                 ps.setTimestamp(13, now);
-                ps.setBoolean(14, false);
+                ps.setNull(14, Types.TIMESTAMP);
             }
 
             @Override

--- a/backend/src/main/java/com/pickeat/backend/restaurant/domain/repository/RestaurantRepository.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/domain/repository/RestaurantRepository.java
@@ -18,10 +18,10 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
                 and (:isExcluded IS NULL OR r.isExcluded = :isExcluded)
             """)
     List<Restaurant> findByPickeatIdAndIsExcludedIfProvided(@Param("pickeatId") Long pickeatId,
-                                                            @Param("isExcluded") Boolean isExcluded);
+            @Param("isExcluded") Boolean isExcluded);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query(value = "UPDATE restaurant SET deleted = true WHERE pickeat_id IN (:pickeatIds)", nativeQuery = true)
+    @Query(value = "UPDATE restaurant SET deleted_at = NOW() WHERE pickeat_id IN (:pickeatIds)", nativeQuery = true)
     int deleteByPickeatIds(@Param("pickeatIds") List<Long> pickeatIds);
 
     List<Restaurant> findByPickeatIdIn(Collection<Long> pickeatIds);

--- a/backend/src/main/java/com/pickeat/backend/room/domain/Room.java
+++ b/backend/src/main/java/com/pickeat/backend/room/domain/Room.java
@@ -6,10 +6,14 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE room SET deleted_at = NOW() WHERE id = ?")
 public class Room extends BaseEntity {
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/pickeat/backend/room/domain/RoomUser.java
+++ b/backend/src/main/java/com/pickeat/backend/room/domain/RoomUser.java
@@ -6,10 +6,14 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE room_user SET deleted_at = NOW() WHERE id = ?")
 public class RoomUser extends BaseEntity {
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/pickeat/backend/template/domain/Template.java
+++ b/backend/src/main/java/com/pickeat/backend/template/domain/Template.java
@@ -6,10 +6,14 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE template SET deleted_at = NOW() WHERE id = ?")
 public class Template extends BaseEntity {
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/pickeat/backend/template/domain/TemplateWish.java
+++ b/backend/src/main/java/com/pickeat/backend/template/domain/TemplateWish.java
@@ -7,10 +7,14 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE template_wish SET deleted_at = NOW() WHERE id = ?")
 public class TemplateWish extends BaseEntity {
 
     private RestaurantInfo restaurantInfo;

--- a/backend/src/main/java/com/pickeat/backend/user/application/UserService.java
+++ b/backend/src/main/java/com/pickeat/backend/user/application/UserService.java
@@ -11,6 +11,7 @@ import com.pickeat.backend.user.domain.repository.UserRepository;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +31,7 @@ public class UserService {
     public UserResponse createUser(SignupRequest request, ProviderPrincipal providerPrincipal) {
         validateDuplicateNickname(request.nickname());
         User user = new User(request.nickname(), providerPrincipal.providerId(), providerPrincipal.provider());
-        userRepository.save(user);
+        saveUser(user);
         return UserResponse.from(user);
     }
 
@@ -48,12 +49,6 @@ public class UserService {
         return UserResponse.from(user);
     }
 
-    private void validateDuplicateNickname(String nickname) {
-        if (userRepository.existsByNickname(nickname)) {
-            throw new BusinessException(ErrorCode.ALREADY_NICKNAME_EXISTS);
-        }
-    }
-
     public List<UserResponse> searchByNickname(String nickname) {
         List<User> users = userRepository.findByNicknameStartsWith(nickname);
 
@@ -68,5 +63,19 @@ public class UserService {
         List<User> users = userRepository.findAllByIdIn(userIds);
 
         return UserResponse.from(users);
+    }
+
+    private void validateDuplicateNickname(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new BusinessException(ErrorCode.ALREADY_NICKNAME_EXISTS);
+        }
+    }
+
+    private void saveUser(User user) {
+        try {
+            userRepository.save(user);
+        } catch (DataIntegrityViolationException exception) {
+            throw new BusinessException(ErrorCode.ALREADY_NICKNAME_EXISTS);
+        }
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/user/application/UserService.java
+++ b/backend/src/main/java/com/pickeat/backend/user/application/UserService.java
@@ -35,6 +35,12 @@ public class UserService {
         return UserResponse.from(user);
     }
 
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = getUser(userId);
+        userRepository.delete(user);
+    }
+
     public UserResponse findByNickName(String nickname) {
         User user = userRepository.findByNickname(nickname)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -43,9 +49,7 @@ public class UserService {
     }
 
     public UserResponse getById(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
+        User user = getUser(userId);
         return UserResponse.from(user);
     }
 
@@ -77,5 +81,10 @@ public class UserService {
         } catch (DataIntegrityViolationException exception) {
             throw new BusinessException(ErrorCode.ALREADY_NICKNAME_EXISTS);
         }
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/user/domain/User.java
+++ b/backend/src/main/java/com/pickeat/backend/user/domain/User.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLDelete(sql = "UPDATE users SET deleted_at = NOW() WHERE id = ?")
 public class User extends BaseEntity {
 
+    //TODO: 테스트 컨테이너 도입후 불필요한 유니크 제약 조건 제거  (2026-02-5, 목, 17:16)
     @Column(nullable = false, unique = true)
     private String nickname;
 

--- a/backend/src/main/java/com/pickeat/backend/user/domain/User.java
+++ b/backend/src/main/java/com/pickeat/backend/user/domain/User.java
@@ -7,11 +7,15 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE users SET deleted_at = NOW() WHERE id = ?")
 public class User extends BaseEntity {
 
     @Column(nullable = false, unique = true)

--- a/backend/src/main/java/com/pickeat/backend/user/ui/UserController.java
+++ b/backend/src/main/java/com/pickeat/backend/user/ui/UserController.java
@@ -7,6 +7,7 @@ import com.pickeat.backend.user.ui.api.UserApiSpec;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +38,11 @@ public class UserController implements UserApiSpec {
     public ResponseEntity<List<UserResponse>> getUsers(@RequestParam String nickname) {
         List<UserResponse> response = userService.searchByNickname(nickname);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/users")
+    public ResponseEntity<Void> deleteUser(@LoginUserId Long userId) {
+        userService.deleteUser(userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/user/ui/api/UserApiSpec.java
+++ b/backend/src/main/java/com/pickeat/backend/user/ui/api/UserApiSpec.java
@@ -130,4 +130,58 @@ public interface UserApiSpec {
             )
     })
     ResponseEntity<List<UserResponse>> getUsers(@Parameter(description = "검색할 닉네임") @RequestParam String nickname);
+
+    @Operation(
+            summary = "사용자 삭제",
+            description = "로그인된 사용자의 계정을 삭제합니다. (로그인 필요)",
+            operationId = "deleteUser",
+            security = @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "UserAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "사용자 삭제 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProblemDetail.class),
+                            examples = @ExampleObject(
+                                    name = "UNAUTHORIZED",
+                                    value = """
+                                            {
+                                                "type": "about:blank",
+                                                "title": "UNAUTHORIZED",
+                                                "status": 401,
+                                                "detail": "인증 정보가 유효하지 않습니다.",
+                                                "instance": "/api/v1/users/me"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 사용자",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProblemDetail.class),
+                            examples = @ExampleObject(
+                                    name = "USER_NOT_FOUND",
+                                    value = """
+                                            {
+                                                "type": "about:blank",
+                                                "title": "USER_NOT_FOUND",
+                                                "status": 404,
+                                                "detail": "사용자를 찾을 수 없습니다.",
+                                                "instance": "/api/v1/users/me"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<Void> deleteUser(@Parameter(hidden = true) Long userId);
 }

--- a/backend/src/main/java/com/pickeat/backend/wish/domain/Wish.java
+++ b/backend/src/main/java/com/pickeat/backend/wish/domain/Wish.java
@@ -8,10 +8,14 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE wish SET deleted_at = NOW() WHERE id = ?")
 public class Wish extends BaseEntity {
 
     @Column(nullable = false)

--- a/backend/src/main/resources/db/migration/V17__create_deleted_at_columns.sql
+++ b/backend/src/main/resources/db/migration/V17__create_deleted_at_columns.sql
@@ -1,0 +1,23 @@
+ALTER TABLE participant       ADD COLUMN deleted_at DATETIME NULL;
+ALTER TABLE pickeat           ADD COLUMN deleted_at DATETIME NULL;
+ALTER TABLE pickeat_result    ADD COLUMN deleted_at DATETIME NULL;
+ALTER TABLE restaurant        ADD COLUMN deleted_at DATETIME NULL;
+ALTER TABLE restaurant_like   ADD COLUMN deleted_at DATETIME NULL;
+ALTER TABLE room              ADD COLUMN deleted_at DATETIME NULL;
+ALTER TABLE room_user         ADD COLUMN deleted_at DATETIME NULL;
+ALTER TABLE template          ADD COLUMN deleted_at DATETIME NULL;
+ALTER TABLE template_wish     ADD COLUMN deleted_at DATETIME NULL;
+ALTER TABLE users             ADD COLUMN deleted_at DATETIME NULL;
+ALTER TABLE wish              ADD COLUMN deleted_at DATETIME NULL;
+
+UPDATE participant       SET deleted_at = NOW() WHERE deleted = 1;
+UPDATE pickeat           SET deleted_at = NOW() WHERE deleted = 1;
+UPDATE pickeat_result    SET deleted_at = NOW() WHERE deleted = 1;
+UPDATE restaurant        SET deleted_at = NOW() WHERE deleted = 1;
+UPDATE restaurant_like   SET deleted_at = NOW() WHERE deleted = 1;
+UPDATE room              SET deleted_at = NOW() WHERE deleted = 1;
+UPDATE room_user         SET deleted_at = NOW() WHERE deleted = 1;
+UPDATE template          SET deleted_at = NOW() WHERE deleted = 1;
+UPDATE template_wish     SET deleted_at = NOW() WHERE deleted = 1;
+UPDATE users             SET deleted_at = NOW() WHERE deleted = 1;
+UPDATE wish              SET deleted_at = NOW() WHERE deleted = 1;

--- a/backend/src/main/resources/db/migration/V18__change_index_abount_deleted.sql
+++ b/backend/src/main/resources/db/migration/V18__change_index_abount_deleted.sql
@@ -1,0 +1,12 @@
+CREATE INDEX idx_pickeat_deleted_at_updated_at
+ON pickeat (deleted_at, updated_at);
+
+CREATE INDEX idx_room_user_room_id_deleted_at
+ON room_user (room_id, deleted_at);
+
+CREATE INDEX idx_room_user_user_id_deleted_at
+ON room_user (user_id, deleted_at);
+
+DROP INDEX idx_pickeat_deleted_updated_at ON pickeat;
+DROP INDEX idx_room_user_room_id_deleted ON room_user;
+DROP INDEX idx_room_user_user_id_deleted ON room_user;

--- a/backend/src/main/resources/db/migration/V19__drop_deleted_columns.sql
+++ b/backend/src/main/resources/db/migration/V19__drop_deleted_columns.sql
@@ -1,0 +1,11 @@
+ALTER TABLE participant       DROP COLUMN deleted;
+ALTER TABLE pickeat           DROP COLUMN deleted;
+ALTER TABLE pickeat_result    DROP COLUMN deleted;
+ALTER TABLE restaurant        DROP COLUMN deleted;
+ALTER TABLE restaurant_like   DROP COLUMN deleted;
+ALTER TABLE room              DROP COLUMN deleted;
+ALTER TABLE room_user         DROP COLUMN deleted;
+ALTER TABLE template          DROP COLUMN deleted;
+ALTER TABLE template_wish     DROP COLUMN deleted;
+ALTER TABLE users             DROP COLUMN deleted;
+ALTER TABLE wish              DROP COLUMN deleted;

--- a/backend/src/main/resources/db/migration/V20__create_user_email_uk.sql
+++ b/backend/src/main/resources/db/migration/V20__create_user_email_uk.sql
@@ -1,0 +1,24 @@
+-- -------------------------------
+-- 유저 테이블에 nickname 컬럼 기준 가상 필드 생성
+-- -------------------------------
+ALTER TABLE users
+ADD COLUMN nickname_active VARCHAR(255)
+GENERATED ALWAYS AS (
+  CASE
+    WHEN deleted_at IS NULL THEN nickname
+    ELSE NULL
+  END
+) STORED;
+
+-- -------------------------------
+-- nickname_active 가상 필드를 통해 유니크 조건 적용
+-- -------------------------------
+CREATE UNIQUE INDEX uk_users_nickname_active
+ON users (nickname_active);
+
+-- -------------------------------
+-- 기존 nickname 관련 인덱스 수정
+-- -------------------------------
+DROP INDEX uk_users_nickname ON users;
+CREATE INDEX idx_users_nickname_deleted_at
+ON users (nickname, deleted_at);

--- a/backend/src/test/java/com/pickeat/backend/user/application/UserServiceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/user/application/UserServiceTest.java
@@ -232,4 +232,28 @@ class UserServiceTest {
             assertThat(results).hasSize(2);
         }
     }
+
+    @Nested
+    @DisplayName("유저 삭제 케이스")
+    class 유저_삭제_케이스 {
+
+        @Test
+        @DisplayName("유저 삭제 성공")
+        void findUsersByRoomIdSuccess() {
+            // given
+            User user = new User("유저1", 1L, "kakao");
+            entityManager.persist(user);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            userService.deleteUser(user.getId());
+
+            // then
+            assertThat(entityManager.find(User.class, user.getId())).isNull();
+        }
+
+        //TODO: 테스트컨테이너 도입후 유저 삭제 후 동일 닉네임으로 재가입하는 테스트 추가 (현재는 직접 실행해서 확인한 상태)  (2026-02-5, 목, 17:54)
+    }
 }

--- a/backend/src/test/resources/init/template_data.sql
+++ b/backend/src/test/resources/init/template_data.sql
@@ -1,61 +1,61 @@
 -- 운영자 유저 생성
-INSERT INTO users (nickname, provider_id, provider, created_at, updated_at, deleted)
-VALUES ('운영자', 1, 'SERVER', NOW(), NOW(), false);
+INSERT INTO users (nickname, provider_id, provider, created_at, updated_at, deleted_at)
+VALUES ('운영자', 1, 'SERVER', NOW(), NOW(), null);
 
 -- 잠실 Room 데이터
-INSERT INTO room (name, created_at, updated_at, deleted)
-VALUES ('운영자 잠실 Room', NOW(), NOW(), false);
+INSERT INTO room (name, created_at, updated_at, deleted_at)
+VALUES ('운영자 잠실 Room', NOW(), NOW(), null);
 
 -- RoomUser 연결 데이터
-INSERT INTO room_user (room_id, user_id, created_at, updated_at, deleted)
-VALUES (1, 1, NOW(), NOW(), false);
+INSERT INTO room_user (room_id, user_id, created_at, updated_at, deleted_at)
+VALUES (1, 1, NOW(), NOW(), null);
 
 -- 잠실 WishList 데이터
-INSERT INTO wish_list (name, room_id, is_template, created_at, updated_at, deleted)
-VALUES ('잠실', 1, true, NOW(), NOW(), false);
+INSERT INTO wish_list (name, room_id, is_template, created_at, updated_at, deleted_at)
+VALUES ('잠실', 1, true, NOW(), NOW(), null);
 
 -- 잠실 Wish 데이터
-INSERT INTO wish (name, food_category, road_address_name, tags, place_url, wish_list_id, created_at, updated_at, deleted) VALUES
-('서해바지락칼국수', 'KOREAN', '서울 송파구 올림픽로35가길 11 한신코아오피스텔 1층 112호', '칼국수, 만두, 파전', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), false),
-('육회바른연어', 'JAPANESE', '서울 송파구 올림픽로35가길 11 한신코어오피스텔 1층 103호', '연어, 육회, 덮밥, 초밥', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), false),
-('연어식당', 'JAPANESE', '서울 송파구 올림픽로35가길 9 잠실푸르지오월드마크 1층', '연어, 덮밥', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), false),
-('성화마라탕', 'CHINESE', '서울 송파구 올림픽로35가길 9 지하1층 39,40호', '마라탕, 마라샹궈, 꿔바로우', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), false),
-('맥도날드', 'OTHERS', '서울 송파구 송파대로 558 월드타워빌딩 1층', '햄버거', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), false),
-('홍수계찜닭', 'KOREAN', '서울 송파구 송파대로 570 타워730 지하1층', '찜닭', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), false);
+INSERT INTO wish (name, food_category, road_address_name, tags, place_url, wish_list_id, created_at, updated_at, deleted_at) VALUES
+('서해바지락칼국수', 'KOREAN', '서울 송파구 올림픽로35가길 11 한신코아오피스텔 1층 112호', '칼국수, 만두, 파전', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), null),
+('육회바른연어', 'JAPANESE', '서울 송파구 올림픽로35가길 11 한신코어오피스텔 1층 103호', '연어, 육회, 덮밥, 초밥', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), null),
+('연어식당', 'JAPANESE', '서울 송파구 올림픽로35가길 9 잠실푸르지오월드마크 1층', '연어, 덮밥', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), null),
+('성화마라탕', 'CHINESE', '서울 송파구 올림픽로35가길 9 지하1층 39,40호', '마라탕, 마라샹궈, 꿔바로우', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), null),
+('맥도날드', 'OTHERS', '서울 송파구 송파대로 558 월드타워빌딩 1층', '햄버거', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), null),
+('홍수계찜닭', 'KOREAN', '서울 송파구 송파대로 570 타워730 지하1층', '찜닭', 'https://place.map.kakao.com/505348601', 1, NOW(), NOW(), null);
 
 -- 잠실 WishPicture 데이터 (서브쿼리 사용)
-INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted)
+INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted_at)
 SELECT w.id, 'pickeat/wish_images/default_images/jamsil_template/서해바지락 칼국수.png',
        'https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/pickeat/wish_images/default_images/jamsil_template/%EC%84%9C%ED%95%B4%EB%B0%94%EC%A7%80%EB%9D%BD+%EC%B9%BC%EA%B5%AD%EC%88%98.png',
-       NOW(), NOW(), false
+       NOW(), NOW(), null
 FROM wish w WHERE w.name = '서해바지락칼국수';
 
-INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted)
+INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted_at)
 SELECT w.id, 'pickeat/wish_images/default_images/jamsil_template/육회바른연어.jpg',
        'https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/pickeat/wish_images/default_images/jamsil_template/%EC%9C%A1%ED%9A%8C%EB%B0%94%EB%A5%B8%EC%97%B0%EC%96%B4.jpg',
-       NOW(), NOW(), false
+       NOW(), NOW(), null
 FROM wish w WHERE w.name = '육회바른연어';
 
-INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted)
+INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted_at)
 SELECT w.id, 'pickeat/wish_images/default_images/jamsil_template/연어식당.jpg',
        'https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/pickeat/wish_images/default_images/jamsil_template/%EC%97%B0%EC%96%B4%EC%8B%9D%EB%8B%B9.jpg',
-       NOW(), NOW(), false
+       NOW(), NOW(), null
 FROM wish w WHERE w.name = '연어식당';
 
-INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted)
+INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted_at)
 SELECT w.id, 'pickeat/wish_images/default_images/jamsil_template/성화마라탕.jpg',
        'https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/pickeat/wish_images/default_images/jamsil_template/%EC%84%B1%ED%99%94%EB%A7%88%EB%9D%BC%ED%83%95.jpg',
-       NOW(), NOW(), false
+       NOW(), NOW(), null
 FROM wish w WHERE w.name = '성화마라탕';
 
-INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted)
+INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted_at)
 SELECT w.id, 'pickeat/wish_images/default_images/jamsil_template/맥도날드.jpg',
        'https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/pickeat/wish_images/default_images/jamsil_template/%EB%A7%A5%EB%8F%84%EB%82%A0%EB%93%9C.jpg',
-       NOW(), NOW(), false
+       NOW(), NOW(), null
 FROM wish w WHERE w.name = '맥도날드';
 
-INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted)
+INSERT INTO wish_picture (wish_id, picture_key, download_url, created_at, updated_at, deleted_at)
 SELECT w.id, 'pickeat/wish_images/default_images/jamsil_template/홍수계찜닭.jpg',
        'https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/pickeat/wish_images/default_images/jamsil_template/%ED%99%8D%EC%88%98%EA%B3%84%EC%B0%9C%EB%8B%AD.jpg',
-       NOW(), NOW(), false
+       NOW(), NOW(), null
 FROM wish w WHERE w.name = '홍수계찜닭';

--- a/backend/src/test/resources/init/template_data_v2.sql
+++ b/backend/src/test/resources/init/template_data_v2.sql
@@ -1,55 +1,55 @@
 -- 템플릿 데이터
-INSERT INTO template (id, name, created_at, updated_at, deleted)
+INSERT INTO template (id, name, created_at, updated_at, deleted_at)
 VALUES
-(1, '데이트 추천 맛집', NOW(), NOW(), FALSE),
-(2, '점심 회식 추천', NOW(), NOW(), FALSE);
+(1, '데이트 추천 맛집', NOW(), NOW(), null),
+(2, '점심 회식 추천', NOW(), NOW(), null);
 
 -- 템플릿 1번의 위시 5개
 INSERT INTO template_wish (
     template_id, name, food_category, road_address_name, distance, place_url, tags,
-    picture_key, picture_url, created_at, updated_at, deleted
+    picture_key, picture_url, created_at, updated_at, deleted_at
 ) VALUES
 (1, '라비타', 'WESTERN', '서울 강남구 테헤란로 25길 10', 250,
  'https://place.map.kakao.com/111111', '분위기좋은,코스요리',
- 'lavita-key', 'https://cdn.example.com/lavita.jpg', NOW(), NOW(), FALSE),
+ 'lavita-key', 'https://cdn.example.com/lavita.jpg', NOW(), NOW(), null),
 
 (1, '더리버', 'OTHERS', '서울 용산구 이태원로 33', 500,
  'https://place.map.kakao.com/111112', '한강뷰,야경맛집',
- 'theriver-key', 'https://cdn.example.com/theriver.jpg', NOW(), NOW(), FALSE),
+ 'theriver-key', 'https://cdn.example.com/theriver.jpg', NOW(), NOW(), null),
 
 (1, '비스트로 루', 'WESTERN', '서울 서초구 서래로 15', 300,
  'https://place.map.kakao.com/111113', '프렌치,조용한분위기',
- 'bistro-key', 'https://cdn.example.com/bistro.jpg', NOW(), NOW(), FALSE),
+ 'bistro-key', 'https://cdn.example.com/bistro.jpg', NOW(), NOW(), null),
 
 (1, '라운지 엘루아', 'OTHERS', '서울 강남구 봉은사로 12', 450,
  'https://place.map.kakao.com/111114', '와인바,분위기좋은',
- 'elua-key', 'https://cdn.example.com/elua.jpg', NOW(), NOW(), FALSE),
+ 'elua-key', 'https://cdn.example.com/elua.jpg', NOW(), NOW(), null),
 
 (1, '루프탑 오리엔트', 'OTHERS', '서울 중구 명동길 23', 600,
  'https://place.map.kakao.com/111115', '루프탑,야경',
- 'orient-key', 'https://cdn.example.com/orient.jpg', NOW(), NOW(), FALSE);
+ 'orient-key', 'https://cdn.example.com/orient.jpg', NOW(), NOW(), null);
 
 -- 템플릿 2번의 위시 5개
 INSERT INTO template_wish (
     template_id, name, food_category, road_address_name, distance, place_url, tags,
-    picture_key, picture_url, created_at, updated_at, deleted
+    picture_key, picture_url, created_at, updated_at, deleted_at
 ) VALUES
 (2, '삼거리 포차', 'KOREAN', '서울 강남구 논현로 45길 8', 200,
  'https://place.map.kakao.com/222111', '분위기좋은,술집',
- 'pocha-key', 'https://cdn.example.com/pocha.jpg', NOW(), NOW(), FALSE),
+ 'pocha-key', 'https://cdn.example.com/pocha.jpg', NOW(), NOW(), null),
 
 (2, '부대통령', 'KOREAN', '서울 마포구 양화로 123', 350,
  'https://place.map.kakao.com/222112', '회식추천,매운맛',
- 'vicepresident-key', 'https://cdn.example.com/vicepresident.jpg', NOW(), NOW(), FALSE),
+ 'vicepresident-key', 'https://cdn.example.com/vicepresident.jpg', NOW(), NOW(), null),
 
 (2, '백리향', 'CHINESE', '서울 중구 세종대로 45', 400,
  'https://place.map.kakao.com/222113', '고급중식,단체석',
- 'baekrihyang-key', 'https://cdn.example.com/baekrihyang.jpg', NOW(), NOW(), FALSE),
+ 'baekrihyang-key', 'https://cdn.example.com/baekrihyang.jpg', NOW(), NOW(), null),
 
 (2, '스시야 마루', 'JAPANESE', '서울 서초구 강남대로 201', 320,
  'https://place.map.kakao.com/222114', '오마카세,점심추천',
- 'maru-key', 'https://cdn.example.com/maru.jpg', NOW(), NOW(), FALSE),
+ 'maru-key', 'https://cdn.example.com/maru.jpg', NOW(), NOW(), null),
 
 (2, '인디언스푼', 'OTHERS', '서울 영등포구 여의대로 88', 600,
  'https://place.map.kakao.com/222115', '이색맛집,커리',
- 'indianspoon-key', 'https://cdn.example.com/indianspoon.jpg', NOW(), NOW(), FALSE);
+ 'indianspoon-key', 'https://cdn.example.com/indianspoon.jpg', NOW(), NOW(), null);


### PR DESCRIPTION
## Issue Number
#3 

## As-Is
<!-- 문제 상황 정의 -->
현재 회원 데이터에 대해 닉네임 컬럼을 기준으로 유니크 제약 조건이 걸려있는 상태입니다.
이때 회원 탈퇴를 하면 회원 정보는 소프트딜리트 처리되어 DB에 남게 되고, 이로 인해 동일 닉네임으로 재가입이 불가능한 버그를 발견했습니다.
소프트딜리트 처리되지 않은 회원들에 한해서만 닉네임 컬럼을 기준으로 조건부 유니크 제약 조건을 걸어 문제를 해결하고자 합니다. (MySQL 기준 가상 필드 컬럼 활용)

## To-Be
<!-- 변경 사항 -->
- [x] 소프트딜리트 처리 방식 변경 (is_deleted -> deleted_at)
    - 소프트딜리트 처리 쿼리 수정
    - deleted_at 컬럼 생성 마이그레이션
    - deleted 관련 인덱싱 전략 수정
    - deleted_at 컬럼 제거 마이그레이션
- [x] 회원 데이터의 닉네임 컬럼에 대한 조건부 유니크 제약 조건 생성
    - 가상 필드 생성
    - 가상 필드에 대한 유니크 제약조건 추가
    - nickname 관련 인덱스 전략 수정
- [x] 회원가입과 탈퇴 API를 다시 구현
    - 기존 회원가입 API 로직 수정
    - 다시 회원탈퇴 API 구현

## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
