### PR TITLE
[Feat] template 관련 백오피스 기능 추가

### DIFF
--- a/backend/docker/docker-compose.local.yml
+++ b/backend/docker/docker-compose.local.yml
@@ -68,4 +68,5 @@ volumes:
 
 networks:
   app-tier:
+    name: app-tier
     driver: bridge

--- a/backend/src/main/java/com/pickeat/backend/restaurant/application/TemplateRestaurantSearchService.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/application/TemplateRestaurantSearchService.java
@@ -23,6 +23,7 @@ public class TemplateRestaurantSearchService {
 
     public List<RestaurantRequest> searchByTemplate(TemplateRestaurantRequest request) {
         Template template = getTemplateById(request.templateId());
+        validateTemplateState(template);
         List<TemplateWish> templateWishes = getTemplateWishById(template);
         return templateWishes.stream()
                 .map(RestaurantRequest::fromTemplateWish)
@@ -36,5 +37,11 @@ public class TemplateRestaurantSearchService {
 
     public List<TemplateWish> getTemplateWishById(Template template) {
         return templateWishRepository.findAllByTemplateId(template.getId());
+    }
+
+    public void validateTemplateState(Template template) {
+        if (!template.getIsActive()) {
+            throw new BusinessException(ErrorCode.TEMPLATE_NOT_FOUND);
+        }
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/template/application/TemplateService.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/TemplateService.java
@@ -21,7 +21,7 @@ public class TemplateService {
 
     public List<TemplateResponse> getTemplates(Long startId, Integer size) {
         Pageable pageable = PageRequest.of(0, size, Sort.by("id").ascending());
-        Slice<Template> templates = templateRepository.findByIdGreaterThan(startId, pageable);
+        Slice<Template> templates = templateRepository.findByIdGreaterThanAndIsActiveTrue(startId, pageable);
         return TemplateResponse.from(templates.toList());
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/template/application/TemplateWishService.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/TemplateWishService.java
@@ -1,7 +1,11 @@
 package com.pickeat.backend.template.application;
 
+import com.pickeat.backend.global.exception.BusinessException;
+import com.pickeat.backend.global.exception.ErrorCode;
 import com.pickeat.backend.template.application.dto.response.TemplateWishResponse;
+import com.pickeat.backend.template.domain.Template;
 import com.pickeat.backend.template.domain.TemplateWish;
+import com.pickeat.backend.template.domain.repository.TemplateRepository;
 import com.pickeat.backend.template.domain.repository.TemplateWishRepository;
 import java.util.Comparator;
 import java.util.List;
@@ -14,11 +18,26 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TemplateWishService {
 
+    private final TemplateRepository templateRepository;
     private final TemplateWishRepository templateWishRepository;
 
     public List<TemplateWishResponse> getWishesFromTemplates(Long templateId) {
+        Template template = getTemplate(templateId);
+        validateTemplateState(template);
+
         List<TemplateWish> wishes = templateWishRepository.findAllByTemplateId(templateId);
         wishes.sort(Comparator.comparing(TemplateWish::getCreatedAt).reversed());
         return TemplateWishResponse.from(wishes);
+    }
+
+    public Template getTemplate(Long templateId) {
+        return templateRepository.findById(templateId).orElseThrow(
+                () -> new BusinessException(ErrorCode.TEMPLATE_NOT_FOUND));
+    }
+
+    public void validateTemplateState(Template template) {
+        if (!template.getIsActive()) {
+            throw new BusinessException(ErrorCode.TEMPLATE_NOT_FOUND);
+        }
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/template/domain/Template.java
+++ b/backend/src/main/java/com/pickeat/backend/template/domain/Template.java
@@ -19,7 +19,11 @@ public class Template extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    public Template(String name) {
+    @Column(nullable = false)
+    private Boolean isActive;
+
+    public Template(String name, boolean isActive) {
         this.name = name;
+        this.isActive = isActive;
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/template/domain/repository/TemplateRepository.java
+++ b/backend/src/main/java/com/pickeat/backend/template/domain/repository/TemplateRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface TemplateRepository extends JpaRepository<Template, Long> {
 
-    Slice<Template> findByIdGreaterThan(
+    Slice<Template> findByIdGreaterThanAndIsActiveTrue(
             @Param("id") Long cursorId,
             Pageable pageable
     );

--- a/backend/src/main/resources/db/migration/V22__add_template_is_active_column.sql
+++ b/backend/src/main/resources/db/migration/V22__add_template_is_active_column.sql
@@ -1,0 +1,10 @@
+-- -------------------------------
+-- Template 테이블에 isActive 컬럼 추가
+-- -------------------------------
+ALTER TABLE template
+ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT true;
+
+-- -------------------------------
+-- Template 테이블에 인덱스 추가
+-- -------------------------------
+CREATE INDEX idx_template_active_id ON template (is_active, id);

--- a/backend/src/main/resources/db/migration/V23__set_nullable_template_wish_distance_column.sql
+++ b/backend/src/main/resources/db/migration/V23__set_nullable_template_wish_distance_column.sql
@@ -1,0 +1,4 @@
+-- -------------------------------
+-- TemplateWish 테이블의 distance 컬럼을 nullable로 변경
+-- -------------------------------A
+ALTER TABLE template_wish MODIFY COLUMN distance int NULL;

--- a/backend/src/test/java/com/pickeat/backend/support/fixture/TemplateFixture.java
+++ b/backend/src/test/java/com/pickeat/backend/support/fixture/TemplateFixture.java
@@ -5,6 +5,10 @@ import com.pickeat.backend.template.domain.Template;
 public class TemplateFixture {
 
     public static Template create() {
-        return new Template("템플릿");
+        return new Template("템플릿", true);
+    }
+
+    public static Template create(boolean isActive) {
+        return new Template("템플릿", isActive);
     }
 }

--- a/backend/src/test/java/com/pickeat/backend/template/application/TemplateServiceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/template/application/TemplateServiceTest.java
@@ -1,6 +1,7 @@
 package com.pickeat.backend.template.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickeat.backend.support.DatabaseSliceTest;
 import com.pickeat.backend.support.fixture.TemplateFixture;
@@ -49,6 +50,31 @@ class TemplateServiceTest extends DatabaseSliceTest {
             assertThat(response)
                     .extracting(TemplateResponse::id)
                     .containsExactlyInAnyOrderElementsOf(templateIds);
+        }
+
+        @Test
+        void 비활성_상태인_템플릿은_조회되지_않는다() {
+            // given
+            Template activeTemplate = TemplateFixture.create(true);
+            entityManager.persist(activeTemplate);
+
+            Template inactiveTemplate = TemplateFixture.create(false);
+            entityManager.persist(inactiveTemplate);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            List<TemplateResponse> response = templateService.getTemplates(0L, 10);
+
+            // then
+            assertAll(
+                    () -> assertThat(response)
+                            .extracting(TemplateResponse::id)
+                            .contains(activeTemplate.getId())
+                            .doesNotContain(inactiveTemplate.getId()),
+                    () -> assertThat(response).hasSize(1)
+            );
         }
     }
 }

--- a/backend/src/test/java/com/pickeat/backend/template/application/TemplateWishServiceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/template/application/TemplateWishServiceTest.java
@@ -1,7 +1,9 @@
 package com.pickeat.backend.template.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.pickeat.backend.global.exception.BusinessException;
 import com.pickeat.backend.support.DatabaseSliceTest;
 import com.pickeat.backend.support.fixture.TemplateFixture;
 import com.pickeat.backend.support.fixture.TemplateWishFixture;
@@ -53,6 +55,32 @@ class TemplateWishServiceTest extends DatabaseSliceTest {
             assertThat(response)
                     .extracting(TemplateWishResponse::id)
                     .containsExactlyElementsOf(templateWishIds);
+        }
+
+        @Test
+        void 존재하지_않는_템플릿일_경우_예외발생() {
+            // given
+            Long invalidId = 9999L;
+
+            // when & then
+            assertThatThrownBy(() -> templateWishService.getWishesFromTemplates(invalidId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("템플릿을 찾을 수 없습니다.");
+        }
+
+        @Test
+        void 비활성_상태의_템플릿일_경우_예외발생() {
+            // given
+            Template inactiveTemplate = TemplateFixture.create(false);
+            entityManager.persist(inactiveTemplate);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when & then
+            assertThatThrownBy(() -> templateWishService.getWishesFromTemplates(inactiveTemplate.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("템플릿을 찾을 수 없습니다.");
         }
     }
 }

--- a/backend/src/test/resources/init/template_data_v2.sql
+++ b/backend/src/test/resources/init/template_data_v2.sql
@@ -1,8 +1,8 @@
 -- 템플릿 데이터
-INSERT INTO template (id, name, created_at, updated_at, deleted_at)
+INSERT INTO template (id, name, is_active, created_at, updated_at, deleted_at)
 VALUES
-(1, '데이트 추천 맛집', NOW(), NOW(), null),
-(2, '점심 회식 추천', NOW(), NOW(), null);
+(1, '데이트 추천 맛집', 1, NOW(), NOW(), null),
+(2, '점심 회식 추천', 1, NOW(), NOW(), null);
 
 -- 템플릿 1번의 위시 5개
 INSERT INTO template_wish (


### PR DESCRIPTION
## Issue Number
#15 

## As-Is
<!-- 문제 상황 정의 -->
템플릿 데이터는 일반 사용자는 읽기만 가능하고 수정은 운영자만 할 수 있는 데이터로, 기존에는 운영자가 DB 관리 툴을 직접 사용해 수정해왔습니다. 운영 효율을 높이기 위해 별도의 백오피스 서버를 구축하고 템플릿 관련 관리 기능을 제공하고자 니다.

## To-Be
<!-- 변경 사항 -->

### 구현 목록
- 백오피스 서버 구축
- Template 관리 기능 구현
- TemplateWish 관리 기능 구현
- TemplateWish 이미지 관리 기능 구현

### 유의했던 점
- 관리자가 템플릿을 추가·수정·삭제하는 도중 해당 템플릿이 사용자에게 노출되는 문제가 있었습니다. 이를 해결하기 위해 템플릿에 활성화 여부 필드를 추가하고, 백오피스에서는 비활성화 상태의 템플릿만 관리하도록 구현했습니다.

## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
Closed #15 