### PR TITLE
[Refactor] template 관련 캐싱 처리

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 
     implementation 'com.bucket4j:bucket4j_jdk17-core:8.17.0'
     implementation 'com.bucket4j:bucket4j_jdk17-lettuce:8.17.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/pickeat/backend/global/cache/CacheChannelTopic.java
+++ b/backend/src/main/java/com/pickeat/backend/global/cache/CacheChannelTopic.java
@@ -1,0 +1,15 @@
+package com.pickeat.backend.global.cache;
+
+import lombok.Getter;
+
+@Getter
+public enum CacheChannelTopic {
+
+    TEMPLATE_TOPIC("template-topic");
+
+    private final String value;
+
+    CacheChannelTopic(String value) {
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/global/cache/CacheConfiguration.java
+++ b/backend/src/main/java/com/pickeat/backend/global/cache/CacheConfiguration.java
@@ -16,13 +16,13 @@ public class CacheConfiguration {
     public CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager();
 
-        cacheManager.registerCustomCache("templateList", Caffeine.newBuilder()
+        cacheManager.registerCustomCache(CacheKey.TEMPLATE_LIST_CACHE_KEY.getValue(), Caffeine.newBuilder()
                 .maximumSize(100)
                 .expireAfterWrite(Duration.ofMinutes(60))
                 .recordStats()
                 .build());
 
-        cacheManager.registerCustomCache("templateWishes", Caffeine.newBuilder()
+        cacheManager.registerCustomCache(CacheKey.TEMPLATE_WISH_CACHE_KEY.getValue(), Caffeine.newBuilder()
                 .maximumSize(5000)
                 .expireAfterWrite(Duration.ofMinutes(60))
                 .recordStats()

--- a/backend/src/main/java/com/pickeat/backend/global/cache/CacheConfiguration.java
+++ b/backend/src/main/java/com/pickeat/backend/global/cache/CacheConfiguration.java
@@ -1,0 +1,33 @@
+package com.pickeat.backend.global.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfiguration {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+
+        cacheManager.registerCustomCache("templateList", Caffeine.newBuilder()
+                .maximumSize(100)
+                .expireAfterWrite(Duration.ofMinutes(60))
+                .recordStats()
+                .build());
+
+        cacheManager.registerCustomCache("templateWishes", Caffeine.newBuilder()
+                .maximumSize(5000)
+                .expireAfterWrite(Duration.ofMinutes(60))
+                .recordStats()
+                .build());
+
+        return cacheManager;
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/global/cache/CacheEventListenerConfiguration.java
+++ b/backend/src/main/java/com/pickeat/backend/global/cache/CacheEventListenerConfiguration.java
@@ -17,7 +17,8 @@ public class CacheEventListenerConfiguration {
     ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
-        container.addMessageListener(templateCacheEventListener, new ChannelTopic("template-topic"));
+        container.addMessageListener(templateCacheEventListener,
+                new ChannelTopic(CacheChannelTopic.TEMPLATE_TOPIC.getValue()));
         return container;
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/global/cache/CacheEventListenerConfiguration.java
+++ b/backend/src/main/java/com/pickeat/backend/global/cache/CacheEventListenerConfiguration.java
@@ -1,0 +1,28 @@
+package com.pickeat.backend.global.cache;
+
+import com.pickeat.backend.template.application.listener.TemplateCacheEventListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+
+@Configuration
+public class CacheEventListenerConfiguration {
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            TemplateCacheEventListener templateCacheEventListener
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+
+        MessageListenerAdapter listAdapter = new MessageListenerAdapter(
+                templateCacheEventListener, "processTemplateCacheInvalidationEvent");
+        container.addMessageListener(listAdapter, new ChannelTopic("template-topic"));
+
+        return container;
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/global/cache/CacheEventListenerConfiguration.java
+++ b/backend/src/main/java/com/pickeat/backend/global/cache/CacheEventListenerConfiguration.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 
 @Configuration
 public class CacheEventListenerConfiguration {
@@ -18,11 +17,7 @@ public class CacheEventListenerConfiguration {
     ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
-
-        MessageListenerAdapter listAdapter = new MessageListenerAdapter(
-                templateCacheEventListener, "processTemplateCacheInvalidationEvent");
-        container.addMessageListener(listAdapter, new ChannelTopic("template-topic"));
-
+        container.addMessageListener(templateCacheEventListener, new ChannelTopic("template-topic"));
         return container;
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/global/cache/CacheKey.java
+++ b/backend/src/main/java/com/pickeat/backend/global/cache/CacheKey.java
@@ -1,0 +1,22 @@
+package com.pickeat.backend.global.cache;
+
+import lombok.Getter;
+
+@Getter
+public enum CacheKey {
+
+    TEMPLATE_LIST_CACHE_KEY(Holder.TEMPLATE_LIST_CACHE_KEY),
+    TEMPLATE_WISH_CACHE_KEY(Holder.TEMPLATE_WISH_CACHE_KEY);
+
+    private final String value;
+
+    CacheKey(String value) {
+        this.value = value;
+    }
+
+    public static class Holder {
+
+        public static final String TEMPLATE_LIST_CACHE_KEY = "templateList";
+        public static final String TEMPLATE_WISH_CACHE_KEY = "templateWishes";
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/template/application/TemplateService.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/TemplateService.java
@@ -5,6 +5,7 @@ import com.pickeat.backend.template.domain.Template;
 import com.pickeat.backend.template.domain.repository.TemplateRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -19,6 +20,7 @@ public class TemplateService {
 
     private final TemplateRepository templateRepository;
 
+    @Cacheable(value = "templateList", key = "#startId + '_' + #size")
     public List<TemplateResponse> getTemplates(Long startId, Integer size) {
         Pageable pageable = PageRequest.of(0, size, Sort.by("id").ascending());
         Slice<Template> templates = templateRepository.findByIdGreaterThanAndIsActiveTrue(startId, pageable);

--- a/backend/src/main/java/com/pickeat/backend/template/application/TemplateService.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/TemplateService.java
@@ -1,5 +1,6 @@
 package com.pickeat.backend.template.application;
 
+import com.pickeat.backend.global.cache.CacheKey.Holder;
 import com.pickeat.backend.template.application.dto.response.TemplateResponse;
 import com.pickeat.backend.template.domain.Template;
 import com.pickeat.backend.template.domain.repository.TemplateRepository;
@@ -20,7 +21,7 @@ public class TemplateService {
 
     private final TemplateRepository templateRepository;
 
-    @Cacheable(value = "templateList", key = "#startId + '_' + #size")
+    @Cacheable(value = Holder.TEMPLATE_LIST_CACHE_KEY, key = "#startId + '_' + #size")
     public List<TemplateResponse> getTemplates(Long startId, Integer size) {
         Pageable pageable = PageRequest.of(0, size, Sort.by("id").ascending());
         Slice<Template> templates = templateRepository.findByIdGreaterThanAndIsActiveTrue(startId, pageable);

--- a/backend/src/main/java/com/pickeat/backend/template/application/TemplateWishService.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/TemplateWishService.java
@@ -1,5 +1,6 @@
 package com.pickeat.backend.template.application;
 
+import com.pickeat.backend.global.cache.CacheKey.Holder;
 import com.pickeat.backend.global.exception.BusinessException;
 import com.pickeat.backend.global.exception.ErrorCode;
 import com.pickeat.backend.template.application.dto.response.TemplateWishResponse;
@@ -22,7 +23,7 @@ public class TemplateWishService {
     private final TemplateRepository templateRepository;
     private final TemplateWishRepository templateWishRepository;
 
-    @Cacheable(value = "templateWishes", key = "#templateId")
+    @Cacheable(value = Holder.TEMPLATE_WISH_CACHE_KEY, key = "#templateId")
     public List<TemplateWishResponse> getWishesFromTemplates(Long templateId) {
         Template template = getTemplate(templateId);
         validateTemplateState(template);

--- a/backend/src/main/java/com/pickeat/backend/template/application/TemplateWishService.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/TemplateWishService.java
@@ -10,6 +10,7 @@ import com.pickeat.backend.template.domain.repository.TemplateWishRepository;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ public class TemplateWishService {
     private final TemplateRepository templateRepository;
     private final TemplateWishRepository templateWishRepository;
 
+    @Cacheable(value = "templateWishes", key = "#templateId")
     public List<TemplateWishResponse> getWishesFromTemplates(Long templateId) {
         Template template = getTemplate(templateId);
         validateTemplateState(template);
@@ -30,12 +32,12 @@ public class TemplateWishService {
         return TemplateWishResponse.from(wishes);
     }
 
-    public Template getTemplate(Long templateId) {
+    private Template getTemplate(Long templateId) {
         return templateRepository.findById(templateId).orElseThrow(
                 () -> new BusinessException(ErrorCode.TEMPLATE_NOT_FOUND));
     }
 
-    public void validateTemplateState(Template template) {
+    private void validateTemplateState(Template template) {
         if (!template.getIsActive()) {
             throw new BusinessException(ErrorCode.TEMPLATE_NOT_FOUND);
         }

--- a/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
@@ -1,15 +1,18 @@
 package com.pickeat.backend.template.application.listener;
 
 import com.pickeat.backend.global.cache.CacheKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class TemplateCacheEventListener {
+public class TemplateCacheEventListener implements MessageListener {
 
     private final CacheManager cacheManager;
 
@@ -17,8 +20,11 @@ public class TemplateCacheEventListener {
         this.cacheManager = cacheManager;
     }
 
-    public void processTemplateCacheInvalidationEvent(String message) {
-        Optional<Long> templateId = parseTemplateCacheInvalidationMessage(message);
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String body = new String(message.getBody(), StandardCharsets.UTF_8);
+
+        Optional<Long> templateId = parseTemplateCacheInvalidationMessage(body);
         if (templateId.isEmpty()) {
             return;
         }

--- a/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
@@ -2,34 +2,39 @@ package com.pickeat.backend.template.application.listener;
 
 import com.pickeat.backend.global.cache.CacheKey;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class TemplateCacheEventListener implements MessageListener {
 
     private final CacheManager cacheManager;
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-
-    public TemplateCacheEventListener(CacheManager cacheManager) {
-        this.cacheManager = cacheManager;
-    }
+    private final TaskExecutor virtualThreadExecutor;
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
         String body = new String(message.getBody(), StandardCharsets.UTF_8);
-        long jitterDelay = ThreadLocalRandom.current().nextLong(500);
-        scheduler.schedule(() -> processTemplateCacheInvalidationEvent(body), jitterDelay, TimeUnit.MILLISECONDS);
+
+        virtualThreadExecutor.execute(() -> {
+            try {
+                long jitterDelay = ThreadLocalRandom.current().nextLong(500);
+                Thread.sleep(Duration.ofMillis(jitterDelay));
+                processTemplateCacheInvalidationEvent(body);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
     }
 
     private void processTemplateCacheInvalidationEvent(String message) {
@@ -53,7 +58,7 @@ public class TemplateCacheEventListener implements MessageListener {
         try {
             return Optional.of(Long.parseLong(message));
         } catch (NumberFormatException e) {
-            log.error("적절하지 않는 템플릿 위시 캐시 무효화 이벤트를 전달받았습니다 : {}", message);
+            log.error("적절하지 않은 템플릿 캐시 무효화 이벤트를 전달받았습니다 : {}", message);
         }
         return Optional.empty();
     }

--- a/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
@@ -3,6 +3,10 @@ package com.pickeat.backend.template.application.listener;
 import com.pickeat.backend.global.cache.CacheKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -15,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class TemplateCacheEventListener implements MessageListener {
 
     private final CacheManager cacheManager;
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     public TemplateCacheEventListener(CacheManager cacheManager) {
         this.cacheManager = cacheManager;
@@ -23,8 +28,12 @@ public class TemplateCacheEventListener implements MessageListener {
     @Override
     public void onMessage(Message message, byte[] pattern) {
         String body = new String(message.getBody(), StandardCharsets.UTF_8);
+        long jitterDelay = ThreadLocalRandom.current().nextLong(500);
+        scheduler.schedule(() -> processTemplateCacheInvalidationEvent(body), jitterDelay, TimeUnit.MILLISECONDS);
+    }
 
-        Optional<Long> templateId = parseTemplateCacheInvalidationMessage(body);
+    private void processTemplateCacheInvalidationEvent(String message) {
+        Optional<Long> templateId = parseTemplateCacheInvalidationMessage(message);
         if (templateId.isEmpty()) {
             return;
         }

--- a/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
@@ -25,7 +25,6 @@ public class TemplateCacheEventListener implements MessageListener {
     @Override
     public void onMessage(Message message, byte[] pattern) {
         String body = new String(message.getBody(), StandardCharsets.UTF_8);
-
         virtualThreadExecutor.execute(() -> {
             try {
                 long jitterDelay = ThreadLocalRandom.current().nextLong(500);
@@ -33,6 +32,8 @@ public class TemplateCacheEventListener implements MessageListener {
                 processTemplateCacheInvalidationEvent(body);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                log.error("템플릿 캐시 무효화 중 예상치 못한 오류 발생: message={}", body, e);
             }
         });
     }

--- a/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
@@ -23,7 +23,7 @@ public class TemplateCacheEventListener {
             return;
         }
 
-        Cache templateListCache = cacheManager.getCache(CacheKey.TEMPLATE_LIST_CACHE_KEY.name());
+        Cache templateListCache = cacheManager.getCache(CacheKey.TEMPLATE_LIST_CACHE_KEY.getValue());
         if (templateListCache != null) {
             templateListCache.clear();
         }

--- a/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
@@ -1,5 +1,6 @@
 package com.pickeat.backend.template.application.listener;
 
+import com.pickeat.backend.global.cache.CacheKey;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
@@ -22,12 +23,12 @@ public class TemplateCacheEventListener {
             return;
         }
 
-        Cache templateListCache = cacheManager.getCache("templateList");
+        Cache templateListCache = cacheManager.getCache(CacheKey.TEMPLATE_LIST_CACHE_KEY.name());
         if (templateListCache != null) {
             templateListCache.clear();
         }
 
-        Cache templateWishCache = cacheManager.getCache("templateWishes");
+        Cache templateWishCache = cacheManager.getCache(CacheKey.TEMPLATE_WISH_CACHE_KEY.getValue());
         if (templateWishCache != null) {
             templateWishCache.evict(templateId.get());
         }

--- a/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
+++ b/backend/src/main/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListener.java
@@ -1,0 +1,44 @@
+package com.pickeat.backend.template.application.listener;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class TemplateCacheEventListener {
+
+    private final CacheManager cacheManager;
+
+    public TemplateCacheEventListener(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    public void processTemplateCacheInvalidationEvent(String message) {
+        Optional<Long> templateId = parseTemplateCacheInvalidationMessage(message);
+        if (templateId.isEmpty()) {
+            return;
+        }
+
+        Cache templateListCache = cacheManager.getCache("templateList");
+        if (templateListCache != null) {
+            templateListCache.clear();
+        }
+
+        Cache templateWishCache = cacheManager.getCache("templateWishes");
+        if (templateWishCache != null) {
+            templateWishCache.evict(templateId.get());
+        }
+    }
+
+    private Optional<Long> parseTemplateCacheInvalidationMessage(String message) {
+        try {
+            return Optional.of(Long.parseLong(message));
+        } catch (NumberFormatException e) {
+            log.error("적절하지 않는 템플릿 위시 캐시 무효화 이벤트를 전달받았습니다 : {}", message);
+        }
+        return Optional.empty();
+    }
+}

--- a/backend/src/test/java/com/pickeat/backend/support/DatabaseSliceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/support/DatabaseSliceTest.java
@@ -1,8 +1,10 @@
 package com.pickeat.backend.support;
 
+import com.pickeat.backend.global.cache.CacheConfiguration;
 import com.pickeat.backend.global.config.VirtualThreadExecutorConfig;
 import com.pickeat.backend.global.limiter.ExternalApiTrafficLimiterConfiguration;
 import com.pickeat.backend.global.utility.JsonParser;
+import com.pickeat.backend.support.utility.CacheCleaner;
 import com.pickeat.backend.support.utility.DatabaseCleaner;
 import com.pickeat.backend.support.utility.StorageCleaner;
 import org.junit.jupiter.api.AfterEach;
@@ -20,7 +22,9 @@ import org.testcontainers.utility.DockerImageName;
 @Import({
         DatabaseCleaner.class,
         StorageCleaner.class,
+        CacheCleaner.class,
         RedisAutoConfiguration.class,
+        CacheConfiguration.class,
         VirtualThreadExecutorConfig.class,
         ExternalApiTrafficLimiterConfiguration.class,
         JsonParser.class})
@@ -35,10 +39,14 @@ public class DatabaseSliceTest {
     @Autowired
     private StorageCleaner storageCleaner;
 
+    @Autowired
+    private CacheCleaner cacheCleaner;
+
     @AfterEach
     void clear() {
         databaseCleaner.execute();
         storageCleaner.execute();
+        cacheCleaner.execute();
     }
 
     static {

--- a/backend/src/test/java/com/pickeat/backend/support/utility/CacheCleaner.java
+++ b/backend/src/test/java/com/pickeat/backend/support/utility/CacheCleaner.java
@@ -1,0 +1,19 @@
+package com.pickeat.backend.support.utility;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("test")
+@RequiredArgsConstructor
+public class CacheCleaner {
+
+    private final CacheManager cacheManager;
+
+    public void execute() {
+        cacheManager.getCacheNames()
+                .forEach(cacheName -> cacheManager.getCache(cacheName).clear());
+    }
+}

--- a/backend/src/test/java/com/pickeat/backend/template/application/TemplateServiceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/template/application/TemplateServiceTest.java
@@ -3,6 +3,7 @@ package com.pickeat.backend.template.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.pickeat.backend.global.cache.CacheKey;
 import com.pickeat.backend.support.DatabaseSliceTest;
 import com.pickeat.backend.support.fixture.TemplateFixture;
 import com.pickeat.backend.template.application.dto.response.TemplateResponse;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
 
 @Import(value = {TemplateService.class})
@@ -20,6 +23,9 @@ class TemplateServiceTest extends DatabaseSliceTest {
 
     @Autowired
     private TestEntityManager entityManager;
+
+    @Autowired
+    private CacheManager cacheManager;
 
     @Autowired
     private TemplateRepository templateRepository;
@@ -74,6 +80,28 @@ class TemplateServiceTest extends DatabaseSliceTest {
                             .contains(activeTemplate.getId())
                             .doesNotContain(inactiveTemplate.getId()),
                     () -> assertThat(response).hasSize(1)
+            );
+        }
+
+        @Test
+        void 템플릿_목록_조회_시_캐시가_적용된다() {
+            // given
+            entityManager.persist(TemplateFixture.create());
+            entityManager.flush();
+
+            Long startId = 0L;
+            Integer size = 10;
+            String expectedCacheKey = startId + "_" + size;
+
+            // when
+            List<TemplateResponse> templates = templateService.getTemplates(startId, size);
+
+            // then
+            Cache cache = cacheManager.getCache(CacheKey.Holder.TEMPLATE_LIST_CACHE_KEY);
+            assertAll(
+                    () -> assertThat(cache).isNotNull(),
+                    () -> assertThat(cache.get(expectedCacheKey)).isNotNull(),
+                    () -> assertThat(cache.get(expectedCacheKey).get()).isEqualTo(templates)
             );
         }
     }

--- a/backend/src/test/java/com/pickeat/backend/template/application/TemplateWishServiceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/template/application/TemplateWishServiceTest.java
@@ -2,7 +2,9 @@ package com.pickeat.backend.template.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.pickeat.backend.global.cache.CacheKey;
 import com.pickeat.backend.global.exception.BusinessException;
 import com.pickeat.backend.support.DatabaseSliceTest;
 import com.pickeat.backend.support.fixture.TemplateFixture;
@@ -17,6 +19,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
 
 @Import(value = {TemplateWishService.class})
@@ -24,6 +28,9 @@ class TemplateWishServiceTest extends DatabaseSliceTest {
 
     @Autowired
     private TestEntityManager entityManager;
+
+    @Autowired
+    private CacheManager cacheManager;
 
     @Autowired
     private TemplateWishRepository templateWishRepository;
@@ -81,6 +88,28 @@ class TemplateWishServiceTest extends DatabaseSliceTest {
             assertThatThrownBy(() -> templateWishService.getWishesFromTemplates(inactiveTemplate.getId()))
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining("템플릿을 찾을 수 없습니다.");
+        }
+
+        @Test
+        void 템플릿_위시_조회_시_캐시가_적용된다() {
+            // given
+            Template template = entityManager.persist(TemplateFixture.create(true));
+            TemplateWish wish = entityManager.persist(TemplateWishFixture.create(template.getId()));
+            entityManager.flush();
+            entityManager.clear();
+
+            Long templateId = template.getId();
+
+            // when
+            List<TemplateWishResponse> serviceResponse = templateWishService.getWishesFromTemplates(templateId);
+
+            // then
+            Cache cache = cacheManager.getCache(CacheKey.Holder.TEMPLATE_WISH_CACHE_KEY);
+            assertAll(
+                    () -> assertThat(cache).isNotNull(),
+                    () -> assertThat(cache.get(templateId)).isNotNull(),
+                    () -> assertThat(cache.get(templateId).get()).isEqualTo(serviceResponse)
+            );
         }
     }
 }

--- a/backend/src/test/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListenerTest.java
+++ b/backend/src/test/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListenerTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickeat.backend.global.cache.CacheKey;
 import com.pickeat.backend.support.DatabaseSliceTest;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.DefaultMessage;
 
 @Import(value = {TemplateCacheEventListener.class})
 class TemplateCacheEventListenerTest extends DatabaseSliceTest {
@@ -32,15 +34,17 @@ class TemplateCacheEventListenerTest extends DatabaseSliceTest {
         wishCache.put(2L, "wish-data-2");
 
         // when
-        eventListener.processTemplateCacheInvalidationEvent(String.valueOf(1L));
+        eventListener.onMessage(new DefaultMessage("template-topic".getBytes(), "1".getBytes()), null);
 
-        // then
-        assertAll(
-                () -> assertThat(listCache.get("0_10")).isNull(),
-                () -> assertThat(listCache.get("10_10")).isNull(),
-                () -> assertThat(wishCache.get(1L)).isNull(),
-                () -> assertThat(wishCache.get(2L).get()).isEqualTo("wish-data-2")
-        );
+        // then (최대 1초 동안 기다리며 캐시가 제대로 무효화되는지 확인)
+        org.awaitility.Awaitility.await()
+                .atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(listCache.get("0_10")).isNull();
+                    assertThat(listCache.get("10_10")).isNull();
+                    assertThat(wishCache.get(1L)).isNull();
+                    assertThat(wishCache.get(2L).get()).isEqualTo("wish-data-2");
+                });
     }
 
     @Test
@@ -55,14 +59,18 @@ class TemplateCacheEventListenerTest extends DatabaseSliceTest {
         wishCache.put(2L, "wish-data-2");
 
         // when
-        eventListener.processTemplateCacheInvalidationEvent("invalid_id");
+        eventListener.onMessage(new DefaultMessage("template-topic".getBytes(), "invalid_id".getBytes()), null);
 
-        // then
-        assertAll(
-                () -> assertThat(listCache.get("0_10").get()).isEqualTo("list-data-1"),
-                () -> assertThat(listCache.get("10_10").get()).isEqualTo("list-data-2"),
-                () -> assertThat(wishCache.get(1L).get()).isEqualTo("wish-data-1"),
-                () -> assertThat(wishCache.get(2L).get()).isEqualTo("wish-data-2")
-        );
+        // then (최대 1초 동안 기다리며 캐시가 무효화되지 않는 것을 확인)
+        org.awaitility.Awaitility.await()
+                .during(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertAll(
+                            () -> assertThat(listCache.get("0_10").get()).isEqualTo("list-data-1"),
+                            () -> assertThat(listCache.get("10_10").get()).isEqualTo("list-data-2"),
+                            () -> assertThat(wishCache.get(1L).get()).isEqualTo("wish-data-1"),
+                            () -> assertThat(wishCache.get(2L).get()).isEqualTo("wish-data-2")
+                    );
+                });
     }
 }

--- a/backend/src/test/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListenerTest.java
+++ b/backend/src/test/java/com/pickeat/backend/template/application/listener/TemplateCacheEventListenerTest.java
@@ -1,0 +1,68 @@
+package com.pickeat.backend.template.application.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.pickeat.backend.global.cache.CacheKey;
+import com.pickeat.backend.support.DatabaseSliceTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Import;
+
+@Import(value = {TemplateCacheEventListener.class})
+class TemplateCacheEventListenerTest extends DatabaseSliceTest {
+
+    @Autowired
+    private TemplateCacheEventListener eventListener;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Test
+    void 캐시_무효화_이벤트_발생시_캐시_무효화() {
+        // given
+        Cache listCache = cacheManager.getCache(CacheKey.Holder.TEMPLATE_LIST_CACHE_KEY);
+        listCache.put("0_10", "list-data-1");
+        listCache.put("10_10", "list-data-2");
+
+        Cache wishCache = cacheManager.getCache(CacheKey.Holder.TEMPLATE_WISH_CACHE_KEY);
+        wishCache.put(1L, "wish-data-1");
+        wishCache.put(2L, "wish-data-2");
+
+        // when
+        eventListener.processTemplateCacheInvalidationEvent(String.valueOf(1L));
+
+        // then
+        assertAll(
+                () -> assertThat(listCache.get("0_10")).isNull(),
+                () -> assertThat(listCache.get("10_10")).isNull(),
+                () -> assertThat(wishCache.get(1L)).isNull(),
+                () -> assertThat(wishCache.get(2L).get()).isEqualTo("wish-data-2")
+        );
+    }
+
+    @Test
+    void 잘못된_메시지_발생시_무시_처리() {
+        // given
+        Cache listCache = cacheManager.getCache(CacheKey.Holder.TEMPLATE_LIST_CACHE_KEY);
+        listCache.put("0_10", "list-data-1");
+        listCache.put("10_10", "list-data-2");
+
+        Cache wishCache = cacheManager.getCache(CacheKey.Holder.TEMPLATE_WISH_CACHE_KEY);
+        wishCache.put(1L, "wish-data-1");
+        wishCache.put(2L, "wish-data-2");
+
+        // when
+        eventListener.processTemplateCacheInvalidationEvent("invalid_id");
+
+        // then
+        assertAll(
+                () -> assertThat(listCache.get("0_10").get()).isEqualTo("list-data-1"),
+                () -> assertThat(listCache.get("10_10").get()).isEqualTo("list-data-2"),
+                () -> assertThat(wishCache.get(1L).get()).isEqualTo("wish-data-1"),
+                () -> assertThat(wishCache.get(2L).get()).isEqualTo("wish-data-2")
+        );
+    }
+}


### PR DESCRIPTION
## Issue Number
#16 

## As-Is
<!-- 문제 상황 정의 -->
템플릿 관련 데이터는 운영자만 수정할 수 있고 일반 사용자는 읽기만 가능한 데이터로, 쓰기에 비해 읽기가 압도적으로 빈번하게 발생하는 특징을 가지고 있습니다. 이러한 특징은 캐싱 적용에 매우 적합하기 때문에, 캐싱을 도입해 DB 조회 부하를 줄이고 응답 속도를 높이고자 했습니다.

## To-Be
<!-- 변경 사항 -->
### Template을 저장/관리하는 로컬 캐시 구축 
- **읽기 전략으로는 Look-Aside 패턴을 적용했습니다.** 
    템플릿 데이터는 사용자에게 매우 자주 노출되는 반면 데이터 크기가 작아 캐싱 효율이 높습니다. 그렇기에 캐시에 데이터가 존재할 경우 DB를 거치지 않고 즉시 응답을 반환하도록 하여 DB 커넥션 부하를 크게 줄였습니다. 또한 캐시 미스가 발생한 경우에만 선택적으로 DB를 조회하도록 설계해, 메모리 자원 역시 효율적으로 활용할 수 있도록 했습니다.
- **쓰기 전략으로는 Write-around와 Cache Invalidation을 결합한 방식을 선택했습니다.** 
    운영자가 백오피스 서버를 통해 템플릿 데이터를 수정하기 전에 템플릿 비활성화를 선행하도록 해서 중간 변경 단계가 사용자에게 보이지 않도록 설계했습니다. 그렇기에 캐시를 업데이트 하는 경우는 발생하지 않고 오직 비활성화된 템플릿에 대한 캐시를 제거하는 작업만이 발생하게 됩니다. 이러한 특징을 가지고 있기 때문에 DB와 캐시를 모두 업데이트하는 Write-Through와 Write-Back 방식이 적합하지 않다고 판단했고, 결과적으로 Write-Around와 캐시 무효화 방식을 선택하게 되었습니다.

### 템플릿 리스트의 캐시 무효화 정책
- templateListCache는 {startId}_{size} 조합의 키를 사용해 페이징 요청에 대한 캐시 히트를 보장하도록 설계했습니다. 특정 템플릿 수정 시 어느 페이지에 속해 있는지 역추적하기 어려웠기에, 정합성을 위해 전체를 초기화하는 정책을 채택했습니다. 트래픽이 첫 페이지에 집중되고 데이터 변경 빈도가 낮아 초기화로 인한 히트율 저하가 미미하다는 점이 주요 판단 근거였습니다. 

### TTL 기반 자동 만료를 통한 이벤트 유실 대처
- 쓰기 작업이 매우 드물고 템플릿 데이터의 정합성이 엄격하게 요구되는 데이터가 아니라는 점을 고려해, 구현이 단순하고 추가 인프라가 필요 없는 TTL 기반 자동 만료 방식을 선택했습니다. 이벤트 손실이 발생하더라도 TTL 만료 후 자동으로 DB에서 최신 데이터를 다시 조회하므로, 서비스 특성상 허용 가능한 수준의 일시적인 데이터 불일치 구간 내에서 충분히 안전하게 운영할 수 있다고 판단했습니다.

### 캐시 삭제 지터를 활용한 캐시 스탬피드 대처 방안 구축
- **TTL로 인해 자동 만료되는 경우**
    분산 환경의 각 서버마다 사용자로부터 API 요청을 받는 시점이 물리적으로 조금씩 다릅니다. 이 요청 시간의 차이로 인해 캐시가 생성되는 시점 또한 서버별로 어긋나게 되며, 결과적으로 별도의 로직 없이도 TTL 만료 시점이 시간축에 따라 자연스럽게 분산되어 DB 부하가 집중되는 것을 방지했습니다.
    
- **캐시 무효화 이벤트로 캐시가 한번에 무효화 되는 경우**
    운영자의 수정으로 인해 Redis Pub/Sub을 통한 무효화 이벤트가 발행될 때, 모든 WAS가 캐시를 즉시 삭제하지 않도록 로직을 구성했습니다. 각 서버가 이벤트를 수신한 후 짧은 무작위 시간(예: 0~500ms) 동안 대기한 뒤 캐시를 무효화함으로써, 순간적으로 모든 서버가 동시에 DB에 쿼리를 날리는 스탬피드 현상을 방지했습니다.

### 결과정리
- Template 리스트 조회 응답 시간 약 45% 개선
- TemplateWish 조회 응답 시간 약 약 49.6% 개선

## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
