### PR TITLE
[Refactor] 힙메모리 크기 조정

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -8,9 +8,9 @@ COPY ../build/libs/*.jar ./app.jar
 
 EXPOSE 8080
 
-ENV JAVA_OPTS="-XX:InitialRAMPercentage=70.0 \
-           -XX:MaxRAMPercentage=70.0 \
-           -XX:MetaspaceSize=128M \
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=50.0 \
+           -XX:MaxRAMPercentage=50.0 \
+           -XX:MetaspaceSize=256M \
            -XX:MaxMetaspaceSize=256M \
            -XX:+UseG1GC \
            -XX:+UseContainerSupport \

--- a/backend/docker/Dockerfile_with_build
+++ b/backend/docker/Dockerfile_with_build
@@ -27,9 +27,9 @@ COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENV JAVA_OPTS="-XX:InitialRAMPercentage=70.0 \
-           -XX:MaxRAMPercentage=70.0 \
-           -XX:MetaspaceSize=128M \
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=50.0 \
+           -XX:MaxRAMPercentage=50.0 \
+           -XX:MetaspaceSize=256M \
            -XX:MaxMetaspaceSize=256M \
            -XX:+UseG1GC \
            -XX:+UseContainerSupport \


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
현재 힙 메모리 크기는 전체 컨테이너 메모리의 70%로 설정되어 있어, 논힙 메모리가 차지할 수 있는 여유 공간은 t4g.small 기준 전체 메모리 2GB의 30%인 약 600MB에 불과합니다. 동일 인스턴스에서 Alloy 등 별도 프로세스가 함께 실행되고 있어 OOM 발생 위험이 존재하므로, 안전성 확보를 위해 힙 메모리 비율을 50%로 하향 조정합니다.

## To-Be
<!-- 변경 사항 -->
- [x] 힙메모리 크기 하향 조정
- [x] 애플케이션의 메모리 사용량 및 GC 빈도와 정지 시간 확인

## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
